### PR TITLE
Minor cleanups in rqt_srv for ROS 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,9 @@
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_msg</exec_depend>
 
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_xmllint</test_depend>
+
   <export>
     <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,7 @@
 <package format="2">
   <name>rqt_srv</name>
   <version>1.2.0</version>
-  <description>A Python GUI plugin for introspecting available ROS message types.
-  Note that the srvs available through this plugin is the ones that are stored
-  on your machine, not on the ROS core your rqt instance connects to.</description>
-
+  <description>A Python GUI plugin for introspecting available ROS service types.</description>
   <maintainer email="geoff@openrobotics.org">Geoffrey Biggs</maintainer>
 
   <license>BSD</license>
@@ -17,7 +14,6 @@
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
   <author email="mikeblautman@gmail.com">Michael Lautman</author>
 
-  <exec_depend>rclpy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_msg</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'A Python GUI plugin for introspecting available ROS service types. '
     ),
     license='BSD',
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rqt_srv = ' + package_name + '.main:main',

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,7 @@ setup(
         'Topic :: Software Development',
     ],
     description=(
-        'A Python GUI plugin for introspecting available ROS message types. ' +
-        'Note that the srvs available through this plugin is the ones that are stored ' +
-        'on your machine, not on the ROS core your rqt instance connects to.'
+        'A Python GUI plugin for introspecting available ROS service types. '
     ),
     license='BSD',
     entry_points={

--- a/src/rqt_srv/services.py
+++ b/src/rqt_srv/services.py
@@ -30,11 +30,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from rqt_py_common import message_helpers
-
 from qt_gui.plugin import Plugin
 
 from rqt_msg.messages_widget import MessagesWidget
+
+from rqt_py_common import message_helpers
 
 
 class Services(Plugin):

--- a/src/rqt_srv/services.py
+++ b/src/rqt_srv/services.py
@@ -44,7 +44,7 @@ class Services(Plugin):
 
     def __init__(self, context):
         super(Services, self).__init__(context)
-        self.setObjectName('servicess')
+        self.setObjectName('services')
         self._widget = MessagesWidget(message_helpers.SRV_MODE)
         self._widget.setWindowTitle('Service Type Browser')
         self._widget.type_label.setText('Service:')

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/test/test_xmllint.py
+++ b/test/test_xmllint.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_xmllint.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.xmllint
+def test_xmllint():
+    rc = main(argv=['.'])
+    assert rc == 0, 'Found errors'


### PR DESCRIPTION
This PR does 2 things:

1. It cleans up the package description to be less ROS 1-specific, and fixes up dependencies to be more correct.
2. It adds in the basic xmllint and flake8 tests, along with fixes for them.