### PR TITLE
Add explicit dependency to python3-pytest.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
This is required by the tests, so should be explicitly listed.