### PR TITLE
fix setuptools deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     license='BSD',
     extras_require={
         'test': [
-            'pytest'
-        ]
+            'pytest',
+        ],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -29,7 +28,11 @@ setup(
         'A Python GUI plugin for introspecting available ROS service types. '
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest'
+        ]
+    },
     entry_points={
         'console_scripts': [
             'rqt_srv = ' + package_name + '.main:main',


### PR DESCRIPTION
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: BSD License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************